### PR TITLE
feat(highscore): --scores flag to view podium board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 docs/plans/
+docs/specs/
+docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $HOME/.cargo/bin/putzen
 ```sh
 $ putzen --help
 
-Usage: putzen <folder> [-v] [-d] [-y] [-L] [-a]
+Usage: putzen [-v] [--scores] [-d] [-y] [-L] [-a] [--] [<folder>]
 
 help keeping your disk clean of build and dependency artifacts
 
@@ -82,12 +82,13 @@ Positional Arguments:
 
 Options:
   -v, --version     show the version number
+  --scores          show the stored highscore board and exit
   -d, --dry-run     dry-run will never delete anything, good for simulations
   -y, --yes-to-all  switch to say yes to all questions
   -L, --follow      follow symbolic links
   -a, --dive-into-hidden-folders
                     dive into hidden folders too, e.g. `.git`
-  --help            display usage information
+  --help, help      display usage information
 ```
 
 ## Alternative Projects

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![crates.io](https://img.shields.io/crates/v/putzen-cli.svg)](https://crates.io/crates/putzen-cli)
 [![dependency status](https://deps.rs/repo/github/sassman/putzen-rs/status.svg)](https://deps.rs/repo/github/sassman/putzen-rs)
 [![Build Status](https://github.com/sassman/putzen-rs/workflows/Build/badge.svg)](https://github.com/sassman/putzen-rs/actions?query=branch%3Amain+workflow%3ABuild+)
-[![LOC](https://tokei.rs/b1/github/sassman/putzen-rs?category=code)](https://tokei.rs/b1/github/sassman/putzen-rs?category=code)
 
 "putzen" is German and means cleaning. It helps keeping your disk clean of build and dependency artifacts safely.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,36 @@ Options:
   --help, help      display usage information
 ```
 
+### Highscores
+
+Every putzen run earns you a little reward. The biggest single cleanup and the biggest total run ever measured are kept as a tiny gold/silver/bronze podium. Keep running it on your machine and watch your records stack up over time — show the board any time with `--scores`:
+
+```
+❯ putzen --scores
+
+   ──── ★ SINGLE CLEANUP ★ ────
+     🥇 Gold
+         40.1GiB · 2026-03-14
+   ────────────────────────────
+     🥈 Silver
+         37.9GiB · 2026-03-10
+   ────────────────────────────
+     🥉 Bronze
+          6.5GiB · 2026-03-14
+   ────────────────────────────
+
+   ──── ★    TOTAL RUN   ★ ────
+     🥇 Gold
+         60.3GiB · 2026-03-14
+   ────────────────────────────
+     🥈 Silver
+         44.6GiB · 2026-03-10
+   ────────────────────────────
+     🥉 Bronze
+         19.6GiB · 2026-04-03
+   ────────────────────────────
+```
+
 ## Alternative Projects
 
 - [kondo](https://github.com/tbillington/kondo)

--- a/src/bin/putzen.rs
+++ b/src/bin/putzen.rs
@@ -28,6 +28,11 @@ struct PutzenCliArgs {
     #[argh(switch, short = 'v')]
     version: bool,
 
+    /// show the stored highscore board and exit
+    #[cfg(feature = "highscore-board")]
+    #[argh(switch)]
+    scores: bool,
+
     /// dry-run will never delete anything, good for simulations
     #[argh(switch, short = 'd')]
     dry_run: bool,
@@ -53,10 +58,15 @@ fn main() -> Result<()> {
     let args: PutzenCliArgs = argh::from_env();
     if args.version {
         println!("{} {}", env!("CARGO_BIN_NAME"), env!("CARGO_PKG_VERSION"));
-        Ok(())
-    } else {
-        visit_path(&args)
+        return Ok(());
     }
+    #[cfg(feature = "highscore-board")]
+    if args.scores {
+        let highscores = putzen_cli::Highscores::load()?;
+        println!("{}", putzen_cli::render_board(&highscores));
+        return Ok(());
+    }
+    visit_path(&args)
 }
 
 fn visit_path(args: &PutzenCliArgs) -> Result<()> {
@@ -181,6 +191,8 @@ mod tests {
 
         let args = PutzenCliArgs {
             version: false,
+            #[cfg(feature = "highscore-board")]
+            scores: false,
             dry_run: false,
             yes_to_all: true,
             follow: false,

--- a/src/highscore/display.rs
+++ b/src/highscore/display.rs
@@ -2,6 +2,19 @@ use crate::highscore::podium::{Medal, Record};
 use crate::highscore::Highscores;
 use crate::HumanReadable;
 
+const STROKE: &str = "─";
+const STAR: &str = "★";
+const MIDDLE_DOT: &str = "·"; // U+00B7 — not • U+2022 bullet, not ∙ U+2219
+const EM_DASH: &str = "—"; // U+2014 — not – U+2013 en dash, not - hyphen
+const TROPHY: &str = "🏆";
+const MEDAL_GOLD: &str = "🥇";
+const MEDAL_SILVER: &str = "🥈";
+const MEDAL_BRONZE: &str = "🥉";
+
+const BANNER_INDENT: &str = "   ";
+const HEADER_SIDE_STROKES: usize = 4;
+const RULE_STROKES: usize = 28;
+
 /// The name of a highscore track, used in display output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrackName {
@@ -37,9 +50,9 @@ pub struct EarnedMedal {
 impl Medal {
     pub fn emoji(&self) -> &'static str {
         match self {
-            Medal::Gold => "\u{1F947}",   // 🥇
-            Medal::Silver => "\u{1F948}", // 🥈
-            Medal::Bronze => "\u{1F949}", // 🥉
+            Medal::Gold => MEDAL_GOLD,
+            Medal::Silver => MEDAL_SILVER,
+            Medal::Bronze => MEDAL_BRONZE,
         }
     }
 
@@ -54,25 +67,24 @@ impl Medal {
 
 /// Banner header line, e.g. `   ──── ★ NEW HIGHSCORE ★ ────`.
 fn banner_header(title: &str) -> String {
-    format!(
-        "   \u{2500}\u{2500}\u{2500}\u{2500} \u{2605} {} \u{2605} \u{2500}\u{2500}\u{2500}\u{2500}",
-        title
-    )
+    let side = STROKE.repeat(HEADER_SIDE_STROKES);
+    format!("{}{} {} {} {} {}", BANNER_INDENT, side, STAR, title, STAR, side)
 }
 
 /// Horizontal rule used as the bottom of a banner / separator between slots.
-fn banner_rule() -> &'static str {
-    "   \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}"
+fn banner_rule() -> String {
+    format!("{}{}", BANNER_INDENT, STROKE.repeat(RULE_STROKES))
 }
 
 /// Render a single medal banner.
 fn render_medal(earned: &EarnedMedal) -> String {
     let size = (earned.size as usize).as_human_readable();
     format!(
-        "\n{}\n     {} {} \u{00B7} {}\n          {}\n{}",
+        "\n{}\n     {} {} {} {}\n          {}\n{}",
         banner_header("NEW HIGHSCORE"),
         earned.medal.emoji(),
         earned.medal.label(),
+        MIDDLE_DOT,
         earned.track,
         size,
         banner_rule(),
@@ -94,7 +106,19 @@ pub fn render_medals(medals: &[EarnedMedal]) -> Option<String> {
 
 /// Return the inline hint string for a new highscore.
 pub fn inline_hint() -> String {
-    "\u{1F3C6} new highscore!".to_string() // 🏆 new highscore!
+    format!("{} new highscore!", TROPHY)
+}
+
+/// Center-pad `s` to `width` chars. Odd overflow goes to the left side.
+fn center_pad(s: &str, width: usize) -> String {
+    let len = s.chars().count();
+    if len >= width {
+        return s.to_string();
+    }
+    let diff = width - len;
+    let left = (diff + 1) / 2;
+    let right = diff / 2;
+    format!("{}{}{}", " ".repeat(left), s, " ".repeat(right))
 }
 
 /// Render one medal slot of the highscore board.
@@ -103,14 +127,17 @@ pub fn inline_hint() -> String {
 fn render_board_slot(medal: Medal, record: Option<&Record>) -> String {
     let detail = match record {
         Some(r) => format!(
-            "{} \u{00B7} {}",
+            "{} {} {}",
             (r.size as usize).as_human_readable(),
+            MIDDLE_DOT,
             r.date
         ),
-        None => "(open \u{2014} be the first!)".to_string(),
+        None => format!("(open {} be the first!)", EM_DASH),
     };
+    // Rule is 31 cols wide; medal emoji sits 2 cols in from the stroke
+    // start, so right-align detail to 29 cols to mirror that margin.
     format!(
-        "     {} {}\n          {}",
+        "     {} {}\n{:>29}",
         medal.emoji(),
         medal.label(),
         detail,
@@ -121,29 +148,33 @@ fn render_board_slot(medal: Medal, record: Option<&Record>) -> String {
 /// Format: per-track banner header, three slots (gold/silver/bronze) each
 /// separated by a banner_rule, blank line between tracks.
 pub fn render_board(highscores: &Highscores) -> String {
+    let tracks = [
+        ("SINGLE CLEANUP", &highscores.single_cleanup),
+        ("TOTAL RUN", &highscores.total_run),
+    ];
+    let title_width = tracks
+        .iter()
+        .map(|(t, _)| t.chars().count())
+        .max()
+        .unwrap();
+
     let mut out = String::new();
-    for (track, podium) in [
-        (TrackName::SingleCleanup, &highscores.single_cleanup),
-        (TrackName::TotalRun, &highscores.total_run),
-    ] {
-        let title = match track {
-            TrackName::SingleCleanup => "SINGLE CLEANUP",
-            TrackName::TotalRun => "TOTAL RUN",
-        };
+    for (title, podium) in tracks {
+        let padded = center_pad(title, title_width);
         out.push('\n');
-        out.push_str(&banner_header(title));
+        out.push_str(&banner_header(&padded));
         out.push('\n');
         out.push_str(&render_board_slot(Medal::Gold, podium.gold.as_ref()));
         out.push('\n');
-        out.push_str(banner_rule());
+        out.push_str(&banner_rule());
         out.push('\n');
         out.push_str(&render_board_slot(Medal::Silver, podium.silver.as_ref()));
         out.push('\n');
-        out.push_str(banner_rule());
+        out.push_str(&banner_rule());
         out.push('\n');
         out.push_str(&render_board_slot(Medal::Bronze, podium.bronze.as_ref()));
         out.push('\n');
-        out.push_str(banner_rule());
+        out.push_str(&banner_rule());
         out.push('\n');
     }
     out
@@ -253,6 +284,27 @@ mod tests {
         assert!(out.contains("be the first"));
     }
 
+    #[test]
+    fn render_board_slot_right_aligns_detail_to_fixed_width() {
+        let short = Record {
+            size: 1_073_741_824,
+            date: "2026-03-15".to_string(),
+        };
+        let long = Record {
+            size: 42_949_672_960,
+            date: "2026-03-15".to_string(),
+        };
+        let out_short = render_board_slot(Medal::Gold, Some(&short));
+        let out_long = render_board_slot(Medal::Gold, Some(&long));
+        let detail_short = out_short.lines().nth(1).unwrap();
+        let detail_long = out_long.lines().nth(1).unwrap();
+        assert_eq!(
+            detail_short.chars().count(),
+            detail_long.chars().count(),
+            "detail lines must have equal char counts for right-alignment"
+        );
+    }
+
     use crate::highscore::podium::Podium;
 
     fn populated_record(size: u64, date: &str) -> Record {
@@ -301,6 +353,32 @@ mod tests {
         assert!(out.contains("2026-01-10"));
         // No open markers when everything is populated
         assert_eq!(out.matches("(open").count(), 0);
+    }
+
+    #[test]
+    fn render_board_banner_headers_have_equal_width() {
+        let highscores = Highscores::default();
+        let out = render_board(&highscores);
+        let header_lines: Vec<&str> = out.lines().filter(|l| l.contains(STAR)).collect();
+        assert_eq!(header_lines.len(), 2);
+        assert_eq!(
+            header_lines[0].chars().count(),
+            header_lines[1].chars().count(),
+            "banner headers for SINGLE CLEANUP and TOTAL RUN must match widths"
+        );
+    }
+
+    #[test]
+    fn render_board_slot_detail_mirrors_left_margin() {
+        // Rule is 31 chars; medal emoji sits 2 chars in from the stroke
+        // start, so the detail line must end 2 chars before the stroke end.
+        let record = Record {
+            size: 1_073_741_824,
+            date: "2026-03-15".to_string(),
+        };
+        let out = render_board_slot(Medal::Gold, Some(&record));
+        let detail_line = out.lines().nth(1).unwrap();
+        assert_eq!(detail_line.chars().count(), 29);
     }
 
     #[test]

--- a/src/highscore/display.rs
+++ b/src/highscore/display.rs
@@ -1,4 +1,4 @@
-use crate::highscore::podium::Medal;
+use crate::highscore::podium::{Medal, Record};
 use crate::HumanReadable;
 
 /// The name of a highscore track, used in display output.
@@ -96,6 +96,26 @@ pub fn inline_hint() -> String {
     "\u{1F3C6} new highscore!".to_string() // 🏆 new highscore!
 }
 
+/// Render one medal slot of the highscore board.
+/// `record: None` renders an "open" placeholder.
+/// The caller is responsible for any surrounding banner_header / banner_rule.
+fn render_board_slot(medal: Medal, record: Option<&Record>) -> String {
+    let detail = match record {
+        Some(r) => format!(
+            "{} \u{00B7} {}",
+            (r.size as usize).as_human_readable(),
+            r.date
+        ),
+        None => "(open \u{2014} be the first!)".to_string(),
+    };
+    format!(
+        "     {} {}\n          {}",
+        medal.emoji(),
+        medal.label(),
+        detail,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,5 +197,26 @@ mod tests {
     fn inline_hint_contains_trophy() {
         let hint = inline_hint();
         assert!(hint.contains("new highscore!"));
+    }
+
+    #[test]
+    fn render_board_slot_populated_contains_size_and_date() {
+        let record = Record {
+            size: 1_073_741_824, // 1 GiB
+            date: "2026-03-15".to_string(),
+        };
+        let out = render_board_slot(Medal::Gold, Some(&record));
+        assert!(out.contains("Gold"));
+        assert!(out.contains("1.0GiB"));
+        assert!(out.contains("2026-03-15"));
+        assert!(!out.contains("open"));
+    }
+
+    #[test]
+    fn render_board_slot_open_contains_marker() {
+        let out = render_board_slot(Medal::Silver, None);
+        assert!(out.contains("Silver"));
+        assert!(out.contains("open"));
+        assert!(out.contains("be the first"));
     }
 }

--- a/src/highscore/display.rs
+++ b/src/highscore/display.rs
@@ -1,4 +1,5 @@
 use crate::highscore::podium::{Medal, Record};
+use crate::highscore::Highscores;
 use crate::HumanReadable;
 
 /// The name of a highscore track, used in display output.
@@ -116,6 +117,38 @@ fn render_board_slot(medal: Medal, record: Option<&Record>) -> String {
     )
 }
 
+/// Render the full two-track highscore board.
+/// Format: per-track banner header, three slots (gold/silver/bronze) each
+/// separated by a banner_rule, blank line between tracks.
+pub fn render_board(highscores: &Highscores) -> String {
+    let mut out = String::new();
+    for (track, podium) in [
+        (TrackName::SingleCleanup, &highscores.single_cleanup),
+        (TrackName::TotalRun,       &highscores.total_run),
+    ] {
+        let title = match track {
+            TrackName::SingleCleanup => "SINGLE CLEANUP",
+            TrackName::TotalRun       => "TOTAL RUN",
+        };
+        out.push('\n');
+        out.push_str(&banner_header(title));
+        out.push('\n');
+        out.push_str(&render_board_slot(Medal::Gold, podium.gold.as_ref()));
+        out.push('\n');
+        out.push_str(banner_rule());
+        out.push('\n');
+        out.push_str(&render_board_slot(Medal::Silver, podium.silver.as_ref()));
+        out.push('\n');
+        out.push_str(banner_rule());
+        out.push('\n');
+        out.push_str(&render_board_slot(Medal::Bronze, podium.bronze.as_ref()));
+        out.push('\n');
+        out.push_str(banner_rule());
+        out.push('\n');
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,5 +251,67 @@ mod tests {
         assert!(out.contains("Silver"));
         assert!(out.contains("open"));
         assert!(out.contains("be the first"));
+    }
+
+    use crate::highscore::podium::Podium;
+
+    fn populated_record(size: u64, date: &str) -> Record {
+        Record { size, date: date.to_string() }
+    }
+
+    #[test]
+    fn render_board_empty_highscores_shows_all_open() {
+        let highscores = Highscores::default();
+        let out = render_board(&highscores);
+        assert!(out.contains("SINGLE CLEANUP"));
+        assert!(out.contains("TOTAL RUN"));
+        // Six "open" markers — three per track
+        assert_eq!(out.matches("(open").count(), 6);
+        // No size units should appear when nothing is populated
+        assert!(!out.contains("GiB"));
+        assert!(!out.contains("MiB"));
+        assert!(!out.contains("KiB"));
+    }
+
+    #[test]
+    fn render_board_fully_populated_shows_all_records() {
+        let mut highscores = Highscores::default();
+        highscores.single_cleanup = Podium {
+            gold:   Some(populated_record(3_000_000_000, "2026-03-15")),
+            silver: Some(populated_record(2_000_000_000, "2026-02-01")),
+            bronze: Some(populated_record(1_000_000_000, "2026-01-20")),
+        };
+        highscores.total_run = Podium {
+            gold:   Some(populated_record(5_500_000_000, "2026-03-15")),
+            silver: Some(populated_record(3_300_000_000, "2026-02-14")),
+            bronze: Some(populated_record(1_100_000_000, "2026-01-10")),
+        };
+        let out = render_board(&highscores);
+        assert!(out.contains("SINGLE CLEANUP"));
+        assert!(out.contains("TOTAL RUN"));
+        assert_eq!(out.matches("Gold").count(),   2);
+        assert_eq!(out.matches("Silver").count(), 2);
+        assert_eq!(out.matches("Bronze").count(), 2);
+        // Dates appear somewhere in the output
+        assert!(out.contains("2026-03-15"));
+        assert!(out.contains("2026-01-10"));
+        // No open markers when everything is populated
+        assert_eq!(out.matches("(open").count(), 0);
+    }
+
+    #[test]
+    fn render_board_partial_track_mixes_populated_and_open() {
+        let mut highscores = Highscores::default();
+        highscores.single_cleanup = Podium {
+            gold:   Some(populated_record(1_073_741_824, "2026-03-15")),
+            silver: None,
+            bronze: None,
+        };
+        let out = render_board(&highscores);
+        // Gold is populated → size + date appear
+        assert!(out.contains("1.0GiB"));
+        assert!(out.contains("2026-03-15"));
+        // 5 open markers: silver+bronze of single-cleanup, all 3 of total-run
+        assert_eq!(out.matches("(open").count(), 5);
     }
 }

--- a/src/highscore/display.rs
+++ b/src/highscore/display.rs
@@ -51,15 +51,30 @@ impl Medal {
     }
 }
 
+/// Banner header line, e.g. `   ──── ★ NEW HIGHSCORE ★ ────`.
+fn banner_header(title: &str) -> String {
+    format!(
+        "   \u{2500}\u{2500}\u{2500}\u{2500} \u{2605} {} \u{2605} \u{2500}\u{2500}\u{2500}\u{2500}",
+        title
+    )
+}
+
+/// Horizontal rule used as the bottom of a banner / separator between slots.
+fn banner_rule() -> &'static str {
+    "   \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}"
+}
+
 /// Render a single medal banner.
 fn render_medal(earned: &EarnedMedal) -> String {
     let size = (earned.size as usize).as_human_readable();
     format!(
-        "\n   \u{2500}\u{2500}\u{2500}\u{2500} \u{2605} NEW HIGHSCORE \u{2605} \u{2500}\u{2500}\u{2500}\u{2500}\n     {} {} \u{00B7} {}\n          {}\n   \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+        "\n{}\n     {} {} \u{00B7} {}\n          {}\n{}",
+        banner_header("NEW HIGHSCORE"),
         earned.medal.emoji(),
         earned.medal.label(),
         earned.track,
         size,
+        banner_rule(),
     )
 }
 

--- a/src/highscore/display.rs
+++ b/src/highscore/display.rs
@@ -124,11 +124,11 @@ pub fn render_board(highscores: &Highscores) -> String {
     let mut out = String::new();
     for (track, podium) in [
         (TrackName::SingleCleanup, &highscores.single_cleanup),
-        (TrackName::TotalRun,       &highscores.total_run),
+        (TrackName::TotalRun, &highscores.total_run),
     ] {
         let title = match track {
             TrackName::SingleCleanup => "SINGLE CLEANUP",
-            TrackName::TotalRun       => "TOTAL RUN",
+            TrackName::TotalRun => "TOTAL RUN",
         };
         out.push('\n');
         out.push_str(&banner_header(title));
@@ -256,7 +256,10 @@ mod tests {
     use crate::highscore::podium::Podium;
 
     fn populated_record(size: u64, date: &str) -> Record {
-        Record { size, date: date.to_string() }
+        Record {
+            size,
+            date: date.to_string(),
+        }
     }
 
     #[test]
@@ -275,21 +278,22 @@ mod tests {
 
     #[test]
     fn render_board_fully_populated_shows_all_records() {
-        let mut highscores = Highscores::default();
-        highscores.single_cleanup = Podium {
-            gold:   Some(populated_record(3_000_000_000, "2026-03-15")),
-            silver: Some(populated_record(2_000_000_000, "2026-02-01")),
-            bronze: Some(populated_record(1_000_000_000, "2026-01-20")),
-        };
-        highscores.total_run = Podium {
-            gold:   Some(populated_record(5_500_000_000, "2026-03-15")),
-            silver: Some(populated_record(3_300_000_000, "2026-02-14")),
-            bronze: Some(populated_record(1_100_000_000, "2026-01-10")),
+        let highscores = Highscores {
+            single_cleanup: Podium {
+                gold: Some(populated_record(3_000_000_000, "2026-03-15")),
+                silver: Some(populated_record(2_000_000_000, "2026-02-01")),
+                bronze: Some(populated_record(1_000_000_000, "2026-01-20")),
+            },
+            total_run: Podium {
+                gold: Some(populated_record(5_500_000_000, "2026-03-15")),
+                silver: Some(populated_record(3_300_000_000, "2026-02-14")),
+                bronze: Some(populated_record(1_100_000_000, "2026-01-10")),
+            },
         };
         let out = render_board(&highscores);
         assert!(out.contains("SINGLE CLEANUP"));
         assert!(out.contains("TOTAL RUN"));
-        assert_eq!(out.matches("Gold").count(),   2);
+        assert_eq!(out.matches("Gold").count(), 2);
         assert_eq!(out.matches("Silver").count(), 2);
         assert_eq!(out.matches("Bronze").count(), 2);
         // Dates appear somewhere in the output
@@ -301,11 +305,13 @@ mod tests {
 
     #[test]
     fn render_board_partial_track_mixes_populated_and_open() {
-        let mut highscores = Highscores::default();
-        highscores.single_cleanup = Podium {
-            gold:   Some(populated_record(1_073_741_824, "2026-03-15")),
-            silver: None,
-            bronze: None,
+        let highscores = Highscores {
+            single_cleanup: Podium {
+                gold: Some(populated_record(1_073_741_824, "2026-03-15")),
+                silver: None,
+                bronze: None,
+            },
+            ..Default::default()
         };
         let out = render_board(&highscores);
         // Gold is populated → size + date appear

--- a/src/highscore/display.rs
+++ b/src/highscore/display.rs
@@ -68,7 +68,10 @@ impl Medal {
 /// Banner header line, e.g. `   ──── ★ NEW HIGHSCORE ★ ────`.
 fn banner_header(title: &str) -> String {
     let side = STROKE.repeat(HEADER_SIDE_STROKES);
-    format!("{}{} {} {} {} {}", BANNER_INDENT, side, STAR, title, STAR, side)
+    format!(
+        "{}{} {} {} {} {}",
+        BANNER_INDENT, side, STAR, title, STAR, side
+    )
 }
 
 /// Horizontal rule used as the bottom of a banner / separator between slots.
@@ -116,7 +119,7 @@ fn center_pad(s: &str, width: usize) -> String {
         return s.to_string();
     }
     let diff = width - len;
-    let left = (diff + 1) / 2;
+    let left = (diff + 1).div_ceil(2);
     let right = diff / 2;
     format!("{}{}{}", " ".repeat(left), s, " ".repeat(right))
 }
@@ -136,12 +139,7 @@ fn render_board_slot(medal: Medal, record: Option<&Record>) -> String {
     };
     // Rule is 31 cols wide; medal emoji sits 2 cols in from the stroke
     // start, so right-align detail to 29 cols to mirror that margin.
-    format!(
-        "     {} {}\n{:>29}",
-        medal.emoji(),
-        medal.label(),
-        detail,
-    )
+    format!("     {} {}\n{:>29}", medal.emoji(), medal.label(), detail,)
 }
 
 /// Render the full two-track highscore board.
@@ -152,11 +150,7 @@ pub fn render_board(highscores: &Highscores) -> String {
         ("SINGLE CLEANUP", &highscores.single_cleanup),
         ("TOTAL RUN", &highscores.total_run),
     ];
-    let title_width = tracks
-        .iter()
-        .map(|(t, _)| t.chars().count())
-        .max()
-        .unwrap();
+    let title_width = tracks.iter().map(|(t, _)| t.chars().count()).max().unwrap();
 
     let mut out = String::new();
     for (title, podium) in tracks {

--- a/src/highscore/mod.rs
+++ b/src/highscore/mod.rs
@@ -1,6 +1,8 @@
 pub mod display;
 pub mod podium;
 
+pub use display::render_board;
+
 use crate::highscore::display::{inline_hint, render_medals, EarnedMedal, TrackName};
 use crate::highscore::podium::{Medal, Podium};
 use crate::observer::RunObserver;

--- a/src/highscore/mod.rs
+++ b/src/highscore/mod.rs
@@ -60,6 +60,26 @@ pub struct Highscores {
     pub total_run: Podium,
 }
 
+impl Highscores {
+    /// Load from the real user config directory.
+    /// Returns `Self::default()` if the file doesn't exist yet.
+    pub fn load() -> std::io::Result<Self> {
+        Self::load_from(highscores_path()?)
+    }
+
+    /// Load from an explicit path (used by tests and by `load`).
+    /// Returns `Self::default()` if the path doesn't exist.
+    pub fn load_from(file_path: PathBuf) -> std::io::Result<Self> {
+        if file_path.exists() {
+            let content = fs::read_to_string(&file_path)?;
+            toml::from_str(&content)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        } else {
+            Ok(Self::default())
+        }
+    }
+}
+
 pub struct HighscoreObserver {
     highscores: Highscores,
     earned_medals: Vec<EarnedMedal>,
@@ -255,5 +275,42 @@ mod tests {
         observer.on_folder_cleaned(1000);
         observer.on_run_complete(1000);
         assert!(path.exists());
+    }
+
+    #[test]
+    fn highscores_load_from_returns_default_when_file_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("does_not_exist.toml");
+        let highscores = Highscores::load_from(path).unwrap();
+        assert!(highscores.single_cleanup.gold.is_none());
+        assert!(highscores.total_run.gold.is_none());
+    }
+
+    #[test]
+    fn highscores_load_from_parses_existing_file() {
+        // Write a file via the observer so we know the format is correct.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("highscores.toml");
+        {
+            let mut observer = HighscoreObserver::load_from(path.clone()).unwrap();
+            observer.on_folder_cleaned(42_000);
+            observer.on_run_complete(42_000);
+        }
+
+        let highscores = Highscores::load_from(path).unwrap();
+        assert_eq!(
+            highscores.single_cleanup.gold.as_ref().unwrap().size,
+            42_000
+        );
+        assert_eq!(highscores.total_run.gold.as_ref().unwrap().size, 42_000);
+    }
+
+    #[test]
+    fn highscores_load_from_rejects_malformed_toml() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("highscores.toml");
+        fs::write(&path, "this is not toml = = {").unwrap();
+        let err = Highscores::load_from(path).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 }

--- a/src/highscore/mod.rs
+++ b/src/highscore/mod.rs
@@ -9,6 +9,17 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+/// Resolve the on-disk path to `highscores.toml` under the user's config dir.
+pub(crate) fn highscores_path() -> std::io::Result<PathBuf> {
+    let config_dir = dirs_lite::config_dir().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Could not determine config directory",
+        )
+    })?;
+    Ok(config_dir.join("putzen").join("highscores.toml"))
+}
+
 /// Mirror `Podium::place` bumping logic on earned medals for a given track.
 /// When a new medal is placed, existing earned medals shift down one tier
 /// and any that fall off the podium are removed.
@@ -58,7 +69,7 @@ pub struct HighscoreObserver {
 impl HighscoreObserver {
     /// Load highscores from disk or create a new empty set.
     pub fn load() -> std::io::Result<Self> {
-        let file_path = Self::highscores_path()?;
+        let file_path = highscores_path()?;
         let (highscores, is_first_run) = if file_path.exists() {
             let content = fs::read_to_string(&file_path)?;
             let highscores: Highscores = toml::from_str(&content)
@@ -94,16 +105,6 @@ impl HighscoreObserver {
             earned_medals: Vec::new(),
             file_path,
         })
-    }
-
-    fn highscores_path() -> std::io::Result<PathBuf> {
-        let config_dir = dirs_lite::config_dir().ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "Could not determine config directory",
-            )
-        })?;
-        Ok(config_dir.join("putzen").join("highscores.toml"))
     }
 
     fn today() -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod decider;
 mod highscore;
 mod observer;
 #[cfg(feature = "highscore-board")]
-pub use crate::highscore::HighscoreObserver;
+pub use crate::highscore::{render_board, HighscoreObserver, Highscores};
 
 pub use crate::cleaner::*;
 pub use crate::decider::*;


### PR DESCRIPTION
## Summary

- adds `--scores` CLI flag that prints the full highscore podium (Single cleanup + Total run), gold/silver/bronze with size and date, no scan performed
- board layout balanced: banner headers for both tracks share one width, detail rows mirror the stroke-to-medal left margin on the right side
- unicode glyphs named as consts and stroke runs built via `repeat`, cutting noise in the layout code

<img width="700" height="796" alt="image" src="https://github.com/user-attachments/assets/6117fcb4-83eb-42f7-974b-921fb87963b0" />

## Test plan

- [x] `cargo test --lib highscore::display` — unit tests incl. new width / margin regression tests
- [x] `cargo run -- --scores` — visual pass with populated and empty highscore files
- [x] `cargo run --` — confirm the flag is additive and normal cleanup flow is untouched