### PR TITLE
feat: descend into .worktrees by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aligned"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +65,16 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "cfg-if"
@@ -226,6 +245,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +390,7 @@ dependencies = [
  "argh",
  "dialoguer",
  "dirs-lite",
+ "globset",
  "jiff",
  "jwalk",
  "remove_dir_all",
@@ -394,6 +433,23 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ highscore-board = ["dep:toml", "dep:dirs-lite", "dep:jiff", "dep:serde"]
 argh = "0.1"
 dialoguer = "0.12"
 jwalk = "0.8"
+globset = "0.4"
 serde = { version = "1", optional = true, features = ["derive"] }
 toml = { version = "1.1", optional = true }
 dirs-lite = { version = "1", optional = true, default-features = false, features = ["favor-xdg-style"] }

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ putzen --help
 
 Usage: putzen [-v] [--scores] [-d] [-y] [-L] [-a] [--no-hidden] [--include-hidden <include-hidden...>] [--] [<folder>]
 
-help keeping your disk clean of build and dependency artifacts Hidden directories are normally skipped, except for `.worktrees/` (so colocated git worktrees are cleaned alongside the main checkout). Use `--include-hidden <GLOB>` to override the list, `--no-hidden` to turn it off entirely, or `-a` to descend into every hidden dir. Examples:     putzen                                       # descends into `.worktrees` by default     putzen --include-hidden '.{worktrees,jj}'   # one glob, two hidden dirs     putzen --include-hidden '.work*'             # any hidden dir starting with `.work`     putzen -a                                    # every hidden dir (== '*')     putzen --no-hidden                           # skip all hidden dirs (legacy)
+help keeping your disk clean of build and dependency artifacts
 
 Positional Arguments:
   folder            path where to start with disk clean up.
@@ -98,7 +98,7 @@ Options:
 
 ### Hidden directories
 
-`putzen` skips hidden directories by default, **except for `.worktrees/`** —
+`putzen` skips hidden directories by default, **except for `.worktrees`** —
 projects that colocate git worktrees inside the repo get cleaned in one run.
 
 - `--include-hidden <GLOB>` — pick which hidden dirs to descend into (repeatable). Default: `.worktrees`. Glob is matched against the full basename including the leading dot, so write `.worktrees`, `.{worktrees,jj}`, `.work*`.

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ $HOME/.cargo/bin/putzen
 ```sh
 $ putzen --help
 
-Usage: putzen [-v] [--scores] [-d] [-y] [-L] [-a] [--] [<folder>]
+Usage: putzen [-v] [--scores] [-d] [-y] [-L] [-a] [--no-hidden] [--include-hidden <include-hidden...>] [--] [<folder>]
 
-help keeping your disk clean of build and dependency artifacts
+help keeping your disk clean of build and dependency artifacts Hidden directories are normally skipped, except for `.worktrees/` (so colocated git worktrees are cleaned alongside the main checkout). Use `--include-hidden <GLOB>` to override the list, `--no-hidden` to turn it off entirely, or `-a` to descend into every hidden dir. Examples:     putzen                                       # descends into `.worktrees` by default     putzen --include-hidden '.{worktrees,jj}'   # one glob, two hidden dirs     putzen --include-hidden '.work*'             # any hidden dir starting with `.work`     putzen -a                                    # every hidden dir (== '*')     putzen --no-hidden                           # skip all hidden dirs (legacy)
 
 Positional Arguments:
   folder            path where to start with disk clean up.
@@ -86,9 +86,26 @@ Options:
   -y, --yes-to-all  switch to say yes to all questions
   -L, --follow      follow symbolic links
   -a, --dive-into-hidden-folders
-                    dive into hidden folders too, e.g. `.git`
+                    include every hidden directory (== --include-hidden '*')
+  --no-hidden       skip every hidden directory (overrides the default
+                    `.worktrees`)
+  --include-hidden  glob of hidden directories to descend into (repeatable).
+                    Match is against the full basename including the leading
+                    dot, e.g. `.worktrees`, `.{worktrees,jj}`, `.work*`.
+                    Default: `.worktrees`.
   --help, help      display usage information
 ```
+
+### Hidden directories
+
+`putzen` skips hidden directories by default, **except for `.worktrees/`** —
+projects that colocate git worktrees inside the repo get cleaned in one run.
+
+- `--include-hidden <GLOB>` — pick which hidden dirs to descend into (repeatable). Default: `.worktrees`. Glob is matched against the full basename including the leading dot, so write `.worktrees`, `.{worktrees,jj}`, `.work*`.
+- `--no-hidden` — skip *all* hidden directories (pre-3.x behavior).
+- `-a` / `--dive-into-hidden-folders` — descend into every hidden directory (equivalent to `--include-hidden '*'`).
+
+These three are mutually exclusive.
 
 ### Highscores
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $HOME/.cargo/bin/putzen
 ```sh
 $ putzen --help
 
-Usage: putzen [-v] [--scores] [-d] [-y] [-L] [-a] [--no-hidden] [--include-hidden <include-hidden...>] [--] [<folder>]
+Usage: putzen [-v] [--scores] [-d] [-y] [-L] [-a] [--no-hidden] [--hidden <hidden...>] [--] [<folder>]
 
 help keeping your disk clean of build and dependency artifacts
 
@@ -86,10 +86,10 @@ Options:
   -y, --yes-to-all  switch to say yes to all questions
   -L, --follow      follow symbolic links
   -a, --dive-into-hidden-folders
-                    include every hidden directory (== --include-hidden '*')
+                    include every hidden directory (== --hidden '*')
   --no-hidden       skip every hidden directory (overrides the default
                     `.worktrees`)
-  --include-hidden  glob of hidden directories to descend into (repeatable).
+  --hidden          glob of hidden directories to descend into (repeatable).
                     Match is against the full basename including the leading
                     dot, e.g. `.worktrees`, `.{worktrees,jj}`, `.work*`.
                     Default: `.worktrees`.
@@ -101,9 +101,9 @@ Options:
 `putzen` skips hidden directories by default, **except for `.worktrees`** —
 projects that colocate git worktrees inside the repo get cleaned in one run.
 
-- `--include-hidden <GLOB>` — pick which hidden dirs to descend into (repeatable). Default: `.worktrees`. Glob is matched against the full basename including the leading dot, so write `.worktrees`, `.{worktrees,jj}`, `.work*`.
+- `--hidden <GLOB>` — pick which hidden dirs to descend into (repeatable). Default: `.worktrees`. Glob is matched against the full basename including the leading dot, so write `.worktrees`, `.{worktrees,jj}`, `.work*`.
 - `--no-hidden` — skip *all* hidden directories (pre-3.x behavior).
-- `-a` / `--dive-into-hidden-folders` — descend into every hidden directory (equivalent to `--include-hidden '*'`).
+- `-a` / `--dive-into-hidden-folders` — descend into every hidden directory (equivalent to `--hidden '*'`).
 
 These three are mutually exclusive.
 

--- a/src/bin/putzen.rs
+++ b/src/bin/putzen.rs
@@ -223,16 +223,22 @@ fn visit_path(args: &PutzenCliArgs) -> Result<()> {
     let hidden_policy = HiddenPolicy::from_args(args)
         .map_err(|msg| std::io::Error::new(std::io::ErrorKind::InvalidInput, msg))?;
 
+    // When --no-hidden is set, let jwalk drop hidden entries natively;
+    // otherwise we keep them all and let `hidden_policy` decide in the closure.
+    let jwalk_skip_hidden = args.no_hidden;
+
     ctx.println(format!("Start cleaning at {}", folder.display()));
     for folder in jwalk::WalkDirGeneric::<((), Option<Folder>)>::new(folder)
-        .skip_hidden(false)
+        .skip_hidden(jwalk_skip_hidden)
         .follow_links(args.follow)
         .parallelism(Parallelism::RayonNewPool(8))
         .process_read_dir(move |depth, _, _, children| {
             // 1. drop hidden children disallowed by the policy.
             // depth=None is the virtual root call (parent of the starting dir);
             // we must NOT filter those children or we'd block the starting dir itself.
-            if depth.is_some() {
+            // When `--no-hidden` is in effect, jwalk's own `skip_hidden(true)`
+            // has already dropped them, so we can skip this pass entirely.
+            if depth.is_some() && !hidden_policy.no_hidden {
                 children.retain(|dir_entry_result| {
                     let Ok(dir) = dir_entry_result else {
                         return true;

--- a/src/bin/putzen.rs
+++ b/src/bin/putzen.rs
@@ -35,7 +35,9 @@ impl HiddenPolicy {
         for g in globs {
             b.add(g.clone());
         }
-        let matcher = b.build().map_err(|e| format!("failed to build glob set: {e}"))?;
+        let matcher = b
+            .build()
+            .map_err(|e| format!("failed to build glob set: {e}"))?;
         Ok(Self { no_hidden, matcher })
     }
 
@@ -215,10 +217,14 @@ fn visit_path(args: &PutzenCliArgs) -> Result<()> {
             // we must NOT filter those children or we'd block the starting dir itself.
             if depth.is_some() {
                 children.retain(|dir_entry_result| {
-                    let Ok(dir) = dir_entry_result else { return true; };
+                    let Ok(dir) = dir_entry_result else {
+                        return true;
+                    };
                     let name = dir.file_name();
                     let is_hidden = name.to_str().map(|s| s.starts_with('.')).unwrap_or(false);
-                    if !is_hidden { return true; }
+                    if !is_hidden {
+                        return true;
+                    }
                     hidden_policy.allows_hidden(name)
                 });
             }
@@ -440,10 +446,7 @@ mod tests {
 
     #[test]
     fn from_args_include_hidden_repeatable() {
-        let args = args_from(&[
-            "--include-hidden", ".git",
-            "--include-hidden", ".cache",
-        ]).unwrap();
+        let args = args_from(&["--include-hidden", ".git", "--include-hidden", ".cache"]).unwrap();
         let policy = HiddenPolicy::from_args(&args).unwrap();
         assert!(policy.allows_hidden(".git".as_ref()));
         assert!(policy.allows_hidden(".cache".as_ref()));
@@ -467,7 +470,10 @@ mod tests {
             Ok(_) => panic!("expected parse error for invalid glob"),
         };
         let msg = format!("{early_exit:?}");
-        assert!(msg.contains("[bad"), "error should mention offending input: {msg}");
+        assert!(
+            msg.contains("[bad"),
+            "error should mention offending input: {msg}"
+        );
     }
 
     #[test]
@@ -513,7 +519,13 @@ mod tests {
         // .worktrees/wt1/target  — should be cleaned by default
         let wt_target = root.path().join(".worktrees").join("wt1").join("target");
         std::fs::create_dir_all(&wt_target).unwrap();
-        std::fs::File::create(root.path().join(".worktrees").join("wt1").join("Cargo.toml")).unwrap();
+        std::fs::File::create(
+            root.path()
+                .join(".worktrees")
+                .join("wt1")
+                .join("Cargo.toml"),
+        )
+        .unwrap();
         std::fs::File::create(wt_target.join("artefact")).unwrap();
 
         // .git/target  — should NOT be touched (hidden, not in default include set)
@@ -537,7 +549,10 @@ mod tests {
 
         visit_path(&args).unwrap();
 
-        assert!(!wt_target.exists(), ".worktrees/wt1/target should have been cleaned");
+        assert!(
+            !wt_target.exists(),
+            ".worktrees/wt1/target should have been cleaned"
+        );
         assert!(git_target.exists(), ".git/target must NOT be touched");
     }
 
@@ -546,7 +561,13 @@ mod tests {
         let root = tempfile::TempDir::new().unwrap();
         let wt_target = root.path().join(".worktrees").join("wt1").join("target");
         std::fs::create_dir_all(&wt_target).unwrap();
-        std::fs::File::create(root.path().join(".worktrees").join("wt1").join("Cargo.toml")).unwrap();
+        std::fs::File::create(
+            root.path()
+                .join(".worktrees")
+                .join("wt1")
+                .join("Cargo.toml"),
+        )
+        .unwrap();
         std::fs::File::create(wt_target.join("artefact")).unwrap();
 
         let args = PutzenCliArgs {
@@ -564,6 +585,9 @@ mod tests {
 
         visit_path(&args).unwrap();
 
-        assert!(wt_target.exists(), "--no-hidden must leave .worktrees/wt1/target untouched");
+        assert!(
+            wt_target.exists(),
+            "--no-hidden must leave .worktrees/wt1/target untouched"
+        );
     }
 }

--- a/src/bin/putzen.rs
+++ b/src/bin/putzen.rs
@@ -3,6 +3,7 @@ use std::io::Result;
 use std::path::PathBuf;
 
 use argh::FromArgs;
+use globset::Glob;
 use jwalk::Parallelism;
 
 use putzen_cli::{
@@ -13,6 +14,12 @@ use putzen_cli::{
 
 #[cfg(feature = "highscore-board")]
 use putzen_cli::HighscoreObserver;
+
+/// Parse a single glob pattern. Returns a stringified error including the
+/// offending input so CLI users see what they typed.
+fn parse_glob(s: &str) -> std::result::Result<Glob, String> {
+    Glob::new(s).map_err(|e| format!("invalid glob `{s}`: {e}"))
+}
 
 /// all supported this to clean up
 static FOLDER_TO_CLEANUP: [FileToFolderMatch; 3] = [
@@ -209,5 +216,30 @@ mod tests {
         assert!(root_folder.path().join("Cargo.toml").exists());
         assert!(root_folder.path().join("package.json").exists());
         assert!(second_node_root_folder.join("package.json").exists());
+    }
+
+    #[test]
+    fn parse_glob_accepts_valid_pattern_with_dot() {
+        let g = parse_glob(".worktrees").expect("should parse");
+        assert_eq!(g.glob(), ".worktrees");
+    }
+
+    #[test]
+    fn parse_glob_accepts_brace_expansion() {
+        let g = parse_glob(".{worktrees,jj}").expect("should parse");
+        assert_eq!(g.glob(), ".{worktrees,jj}");
+    }
+
+    #[test]
+    fn parse_glob_accepts_wildcard() {
+        parse_glob("*").expect("should parse wildcard");
+        parse_glob(".work*").expect("should parse prefix wildcard");
+    }
+
+    #[test]
+    fn parse_glob_rejects_invalid_pattern() {
+        let err = parse_glob("[unterminated").expect_err("should fail");
+        // error message includes the offending input so users can self-diagnose
+        assert!(err.contains("[unterminated"), "got: {err}");
     }
 }

--- a/src/bin/putzen.rs
+++ b/src/bin/putzen.rs
@@ -16,10 +16,23 @@ use putzen_cli::{
 #[cfg(feature = "highscore-board")]
 use putzen_cli::HighscoreObserver;
 
+/// Static glob pattern used when neither `-a` nor `--include-hidden` is given.
+const DEFAULT_HIDDEN_GLOB: &str = ".worktrees";
+/// Static glob pattern used for `-a` / `--dive-into-hidden-folders`.
+const ALL_HIDDEN_GLOB: &str = "*";
+
 /// Parse a single glob pattern. Returns a stringified error including the
 /// offending input so CLI users see what they typed.
 fn parse_glob(s: &str) -> std::result::Result<Glob, String> {
     Glob::new(s).map_err(|e| format!("invalid glob `{s}`: {e}"))
+}
+
+/// Cheap first-char heuristic: a glob can only match a hidden basename
+/// (which always starts with `.`) if its pattern starts with `.` or with a
+/// metacharacter that could expand to one (`*`, `?`, `[`, `{`). Anything
+/// else — e.g. `worktrees` — is guaranteed to never match.
+fn pattern_can_match_hidden(pattern: &str) -> bool {
+    matches!(pattern.chars().next(), Some('.' | '*' | '?' | '[' | '{'))
 }
 
 /// Decides whether a hidden directory (basename starts with `.`) is allowed
@@ -74,14 +87,23 @@ impl HiddenPolicy {
 
         // Resolve the active set of globs:
         //   -a            -> ["*"]
-        //   --include-... -> user list
+        //   --include-... -> user list (warn on patterns that can't match a hidden name)
         //   neither       -> [".worktrees"]
         let owned: Vec<Glob> = if dash_a {
-            vec![parse_glob("*").expect("`*` is a valid glob")]
+            vec![parse_glob(ALL_HIDDEN_GLOB).expect("static glob must parse")]
         } else if include_given {
+            for g in &args.include_hidden {
+                let pat = g.glob();
+                if !pattern_can_match_hidden(pat) {
+                    eprintln!(
+                        "warning: --include-hidden `{pat}` does not start with `.`, `*`, `?`, `[`, or `{{` \
+                         — hidden basenames always start with `.`, so this pattern will never match"
+                    );
+                }
+            }
             args.include_hidden.clone()
         } else {
-            vec![parse_glob(".worktrees").expect("`.worktrees` is a valid glob")]
+            vec![parse_glob(DEFAULT_HIDDEN_GLOB).expect("static glob must parse")]
         };
 
         Self::new(false, &owned)
@@ -198,13 +220,8 @@ fn visit_path(args: &PutzenCliArgs) -> Result<()> {
         Box::new(NoOpObserver)
     };
 
-    let hidden_policy = match HiddenPolicy::from_args(args) {
-        Ok(p) => p,
-        Err(msg) => {
-            eprintln!("error: {msg}");
-            std::process::exit(2);
-        }
-    };
+    let hidden_policy = HiddenPolicy::from_args(args)
+        .map_err(|msg| std::io::Error::new(std::io::ErrorKind::InvalidInput, msg))?;
 
     ctx.println(format!("Start cleaning at {}", folder.display()));
     for folder in jwalk::WalkDirGeneric::<((), Option<Folder>)>::new(folder)
@@ -221,7 +238,8 @@ fn visit_path(args: &PutzenCliArgs) -> Result<()> {
                         return true;
                     };
                     let name = dir.file_name();
-                    let is_hidden = name.to_str().map(|s| s.starts_with('.')).unwrap_or(false);
+                    // byte-level check: works for non-UTF-8 names too, and `.` is always ASCII
+                    let is_hidden = name.as_encoded_bytes().first() == Some(&b'.');
                     if !is_hidden {
                         return true;
                     }
@@ -352,6 +370,20 @@ mod tests {
     fn parse_glob_accepts_wildcard() {
         parse_glob("*").expect("should parse wildcard");
         parse_glob(".work*").expect("should parse prefix wildcard");
+    }
+
+    #[test]
+    fn pattern_can_match_hidden_heuristic() {
+        assert!(pattern_can_match_hidden(".worktrees"));
+        assert!(pattern_can_match_hidden(".{worktrees,jj}"));
+        assert!(pattern_can_match_hidden(".work*"));
+        assert!(pattern_can_match_hidden("*"));
+        assert!(pattern_can_match_hidden("?orktrees"));
+        assert!(pattern_can_match_hidden("[.a]worktrees"));
+        assert!(pattern_can_match_hidden("{.a,.b}"));
+        // anything not starting with `.` or a metachar cannot match a hidden basename
+        assert!(!pattern_can_match_hidden("worktrees"));
+        assert!(!pattern_can_match_hidden(""));
     }
 
     #[test]

--- a/src/bin/putzen.rs
+++ b/src/bin/putzen.rs
@@ -96,7 +96,7 @@ static FOLDER_TO_CLEANUP: [FileToFolderMatch; 3] = [
 #[derive(FromArgs)]
 /// help keeping your disk clean of build and dependency artifacts
 ///
-/// Hidden directories are normally skipped, except for `.worktrees/`
+/// Hidden directories are normally skipped, except for `.worktrees`
 /// (so colocated git worktrees are cleaned alongside the main checkout).
 /// Use `--include-hidden <GLOB>` to override the list, `--no-hidden` to
 /// turn it off entirely, or `-a` to descend into every hidden dir.

--- a/src/bin/putzen.rs
+++ b/src/bin/putzen.rs
@@ -16,7 +16,7 @@ use putzen_cli::{
 #[cfg(feature = "highscore-board")]
 use putzen_cli::HighscoreObserver;
 
-/// Static glob pattern used when neither `-a` nor `--include-hidden` is given.
+/// Static glob pattern used when neither `-a` nor `--hidden` is given.
 const DEFAULT_HIDDEN_GLOB: &str = ".worktrees";
 /// Static glob pattern used for `-a` / `--dive-into-hidden-folders`.
 const ALL_HIDDEN_GLOB: &str = "*";
@@ -65,20 +65,20 @@ impl HiddenPolicy {
 
     /// Build a policy from parsed CLI args. Enforces the mutual-exclusion
     /// rules and applies the default `.worktrees` pattern when no
-    /// `--include-hidden` and no `-a` was passed.
+    /// `--hidden` and no `-a` was passed.
     fn from_args(args: &PutzenCliArgs) -> std::result::Result<Self, String> {
         let dash_a = args.dive_into_hidden_folders;
         let no_hidden = args.no_hidden;
-        let include_given = !args.include_hidden.is_empty();
+        let hidden_given = !args.hidden.is_empty();
 
-        if no_hidden && include_given {
-            return Err("`--no-hidden` and `--include-hidden` are mutually exclusive".into());
+        if no_hidden && hidden_given {
+            return Err("`--no-hidden` and `--hidden` are mutually exclusive".into());
         }
         if no_hidden && dash_a {
             return Err("`--no-hidden` and `-a` are mutually exclusive".into());
         }
-        if dash_a && include_given {
-            return Err("`-a` and `--include-hidden` are mutually exclusive".into());
+        if dash_a && hidden_given {
+            return Err("`-a` and `--hidden` are mutually exclusive".into());
         }
 
         if no_hidden {
@@ -86,22 +86,22 @@ impl HiddenPolicy {
         }
 
         // Resolve the active set of globs:
-        //   -a            -> ["*"]
-        //   --include-... -> user list (warn on patterns that can't match a hidden name)
-        //   neither       -> [".worktrees"]
+        //   -a       -> ["*"]
+        //   --hidden -> user list (warn on patterns that can't match a hidden name)
+        //   neither  -> [".worktrees"]
         let owned: Vec<Glob> = if dash_a {
             vec![parse_glob(ALL_HIDDEN_GLOB).expect("static glob must parse")]
-        } else if include_given {
-            for g in &args.include_hidden {
+        } else if hidden_given {
+            for g in &args.hidden {
                 let pat = g.glob();
                 if !pattern_can_match_hidden(pat) {
                     eprintln!(
-                        "warning: --include-hidden `{pat}` does not start with `.`, `*`, `?`, `[`, or `{{` \
+                        "warning: --hidden `{pat}` does not start with `.`, `*`, `?`, `[`, or `{{` \
                          — hidden basenames always start with `.`, so this pattern will never match"
                     );
                 }
             }
-            args.include_hidden.clone()
+            args.hidden.clone()
         } else {
             vec![parse_glob(DEFAULT_HIDDEN_GLOB).expect("static glob must parse")]
         };
@@ -122,15 +122,15 @@ static FOLDER_TO_CLEANUP: [FileToFolderMatch; 3] = [
 ///
 /// Hidden directories are normally skipped, except for `.worktrees`
 /// (so colocated git worktrees are cleaned alongside the main checkout).
-/// Use `--include-hidden <GLOB>` to override the list, `--no-hidden` to
-/// turn it off entirely, or `-a` to descend into every hidden dir.
+/// Use `--hidden <GLOB>` to override the list, `--no-hidden` to turn it
+/// off entirely, or `-a` to descend into every hidden dir.
 ///
 /// Examples:
-///     putzen                                       # descends into `.worktrees` by default
-///     putzen --include-hidden '.{worktrees,jj}'   # one glob, two hidden dirs
-///     putzen --include-hidden '.work*'             # any hidden dir starting with `.work`
-///     putzen -a                                    # every hidden dir (== '*')
-///     putzen --no-hidden                           # skip all hidden dirs (legacy)
+///     putzen                              # descends into `.worktrees` by default
+///     putzen --hidden '.{worktrees,jj}'  # one glob, two hidden dirs
+///     putzen --hidden '.work*'            # any hidden dir starting with `.work`
+///     putzen -a                           # every hidden dir (== '*')
+///     putzen --no-hidden                  # skip all hidden dirs (legacy)
 struct PutzenCliArgs {
     /// show the version number
     #[argh(switch, short = 'v')]
@@ -153,7 +153,7 @@ struct PutzenCliArgs {
     #[argh(switch, short = 'L')]
     follow: bool,
 
-    /// include every hidden directory (== --include-hidden '*')
+    /// include every hidden directory (== --hidden '*')
     #[argh(switch, short = 'a')]
     dive_into_hidden_folders: bool,
 
@@ -165,7 +165,7 @@ struct PutzenCliArgs {
     /// against the full basename including the leading dot, e.g.
     /// `.worktrees`, `.{worktrees,jj}`, `.work*`. Default: `.worktrees`.
     #[argh(option, from_str_fn(parse_glob))]
-    include_hidden: Vec<Glob>,
+    hidden: Vec<Glob>,
 
     /// path where to start with disk clean up.
     #[argh(positional, default = "PathBuf::from(\".\")")]
@@ -339,7 +339,7 @@ mod tests {
             follow: false,
             dive_into_hidden_folders: false,
             no_hidden: false,
-            include_hidden: Vec::new(),
+            hidden: Vec::new(),
             folder: root_folder.path().to_path_buf(),
         };
 
@@ -468,8 +468,8 @@ mod tests {
     }
 
     #[test]
-    fn from_args_include_hidden_overrides_default() {
-        let args = args_from(&["--include-hidden", ".git"]).unwrap();
+    fn from_args_hidden_overrides_default() {
+        let args = args_from(&["--hidden", ".git"]).unwrap();
         let policy = HiddenPolicy::from_args(&args).unwrap();
         assert!(policy.allows_hidden(".git".as_ref()));
         // default `.worktrees` is replaced, not merged
@@ -477,8 +477,8 @@ mod tests {
     }
 
     #[test]
-    fn from_args_include_hidden_repeatable() {
-        let args = args_from(&["--include-hidden", ".git", "--include-hidden", ".cache"]).unwrap();
+    fn from_args_hidden_repeatable() {
+        let args = args_from(&["--hidden", ".git", "--hidden", ".cache"]).unwrap();
         let policy = HiddenPolicy::from_args(&args).unwrap();
         assert!(policy.allows_hidden(".git".as_ref()));
         assert!(policy.allows_hidden(".cache".as_ref()));
@@ -487,7 +487,7 @@ mod tests {
 
     #[test]
     fn from_args_brace_expansion_one_flag_two_dirs() {
-        let args = args_from(&["--include-hidden", ".{worktrees,jj}"]).unwrap();
+        let args = args_from(&["--hidden", ".{worktrees,jj}"]).unwrap();
         let policy = HiddenPolicy::from_args(&args).unwrap();
         assert!(policy.allows_hidden(".worktrees".as_ref()));
         assert!(policy.allows_hidden(".jj".as_ref()));
@@ -496,7 +496,7 @@ mod tests {
     #[test]
     fn from_args_invalid_glob_errors_at_parse_time() {
         // argh's from_str_fn surfaces the error at argument-parse time
-        let result = args_from(&["--include-hidden", "[bad"]);
+        let result = args_from(&["--hidden", "[bad"]);
         let early_exit = match result {
             Err(e) => e,
             Ok(_) => panic!("expected parse error for invalid glob"),
@@ -509,15 +509,15 @@ mod tests {
     }
 
     #[test]
-    fn from_args_no_hidden_conflicts_with_include_hidden() {
-        let args = args_from(&["--no-hidden", "--include-hidden", ".git"]).unwrap();
+    fn from_args_no_hidden_conflicts_with_hidden() {
+        let args = args_from(&["--no-hidden", "--hidden", ".git"]).unwrap();
         let result = HiddenPolicy::from_args(&args);
         let err = match result {
             Err(e) => e,
             Ok(_) => panic!("expected conflict error"),
         };
         assert!(err.contains("--no-hidden"), "got: {err}");
-        assert!(err.contains("--include-hidden"), "got: {err}");
+        assert!(err.contains("--hidden"), "got: {err}");
     }
 
     #[test]
@@ -533,15 +533,15 @@ mod tests {
     }
 
     #[test]
-    fn from_args_dash_a_conflicts_with_include_hidden() {
-        let args = args_from(&["-a", "--include-hidden", ".git"]).unwrap();
+    fn from_args_dash_a_conflicts_with_hidden() {
+        let args = args_from(&["-a", "--hidden", ".git"]).unwrap();
         let result = HiddenPolicy::from_args(&args);
         let err = match result {
             Err(e) => e,
             Ok(_) => panic!("expected conflict error"),
         };
         assert!(err.contains("-a"), "got: {err}");
-        assert!(err.contains("--include-hidden"), "got: {err}");
+        assert!(err.contains("--hidden"), "got: {err}");
     }
 
     #[test]
@@ -575,7 +575,7 @@ mod tests {
             follow: false,
             dive_into_hidden_folders: false,
             no_hidden: false,
-            include_hidden: Vec::new(),
+            hidden: Vec::new(),
             folder: root.path().to_path_buf(),
         };
 
@@ -611,7 +611,7 @@ mod tests {
             follow: false,
             dive_into_hidden_folders: false,
             no_hidden: true,
-            include_hidden: Vec::new(),
+            hidden: Vec::new(),
             folder: root.path().to_path_buf(),
         };
 

--- a/src/bin/putzen.rs
+++ b/src/bin/putzen.rs
@@ -184,12 +184,34 @@ fn visit_path(args: &PutzenCliArgs) -> Result<()> {
         Box::new(NoOpObserver)
     };
 
+    let hidden_policy = match HiddenPolicy::from_args(args) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            std::process::exit(2);
+        }
+    };
+
     ctx.println(format!("Start cleaning at {}", folder.display()));
     for folder in jwalk::WalkDirGeneric::<((), Option<Folder>)>::new(folder)
-        .skip_hidden(!args.dive_into_hidden_folders)
+        .skip_hidden(false)
         .follow_links(args.follow)
         .parallelism(Parallelism::RayonNewPool(8))
-        .process_read_dir(move |_, _, _, children| {
+        .process_read_dir(move |depth, _, _, children| {
+            // 1. drop hidden children disallowed by the policy.
+            // depth=None is the virtual root call (parent of the starting dir);
+            // we must NOT filter those children or we'd block the starting dir itself.
+            if depth.is_some() {
+                children.retain(|dir_entry_result| {
+                    let Ok(dir) = dir_entry_result else { return true; };
+                    let name = dir.file_name();
+                    let is_hidden = name.to_str().map(|s| s.starts_with('.')).unwrap_or(false);
+                    if !is_hidden { return true; }
+                    hidden_policy.allows_hidden(name)
+                });
+            }
+
+            // 2. keep only directories
             children.retain(|dir_entry_result| {
                 dir_entry_result
                     .as_ref()
@@ -197,6 +219,7 @@ fn visit_path(args: &PutzenCliArgs) -> Result<()> {
                     .unwrap_or(false)
             });
 
+            // 3. existing build-artefact marking
             children.iter_mut().for_each(|child| {
                 if let Ok(child) = child {
                     if let Ok(folder) = Folder::try_from(child.path()) {
@@ -469,5 +492,66 @@ mod tests {
         };
         assert!(err.contains("-a"), "got: {err}");
         assert!(err.contains("--include-hidden"), "got: {err}");
+    }
+
+    #[test]
+    fn default_run_descends_into_dot_worktrees_but_not_dot_git() {
+        let root = tempfile::TempDir::new().unwrap();
+
+        // .worktrees/wt1/target  — should be cleaned by default
+        let wt_target = root.path().join(".worktrees").join("wt1").join("target");
+        std::fs::create_dir_all(&wt_target).unwrap();
+        std::fs::File::create(root.path().join(".worktrees").join("wt1").join("Cargo.toml")).unwrap();
+        std::fs::File::create(wt_target.join("artefact")).unwrap();
+
+        // .git/target  — should NOT be touched (hidden, not in default include set)
+        let git_target = root.path().join(".git").join("target");
+        std::fs::create_dir_all(&git_target).unwrap();
+        std::fs::File::create(root.path().join(".git").join("Cargo.toml")).unwrap();
+        std::fs::File::create(git_target.join("artefact")).unwrap();
+
+        let args = PutzenCliArgs {
+            version: false,
+            #[cfg(feature = "highscore-board")]
+            scores: false,
+            dry_run: false,
+            yes_to_all: true,
+            follow: false,
+            dive_into_hidden_folders: false,
+            no_hidden: false,
+            include_hidden: Vec::new(),
+            folder: root.path().to_path_buf(),
+        };
+
+        visit_path(&args).unwrap();
+
+        assert!(!wt_target.exists(), ".worktrees/wt1/target should have been cleaned");
+        assert!(git_target.exists(), ".git/target must NOT be touched");
+    }
+
+    #[test]
+    fn no_hidden_skips_dot_worktrees() {
+        let root = tempfile::TempDir::new().unwrap();
+        let wt_target = root.path().join(".worktrees").join("wt1").join("target");
+        std::fs::create_dir_all(&wt_target).unwrap();
+        std::fs::File::create(root.path().join(".worktrees").join("wt1").join("Cargo.toml")).unwrap();
+        std::fs::File::create(wt_target.join("artefact")).unwrap();
+
+        let args = PutzenCliArgs {
+            version: false,
+            #[cfg(feature = "highscore-board")]
+            scores: false,
+            dry_run: false,
+            yes_to_all: true,
+            follow: false,
+            dive_into_hidden_folders: false,
+            no_hidden: true,
+            include_hidden: Vec::new(),
+            folder: root.path().to_path_buf(),
+        };
+
+        visit_path(&args).unwrap();
+
+        assert!(wt_target.exists(), "--no-hidden must leave .worktrees/wt1/target untouched");
     }
 }

--- a/src/bin/putzen.rs
+++ b/src/bin/putzen.rs
@@ -95,6 +95,18 @@ static FOLDER_TO_CLEANUP: [FileToFolderMatch; 3] = [
 
 #[derive(FromArgs)]
 /// help keeping your disk clean of build and dependency artifacts
+///
+/// Hidden directories are normally skipped, except for `.worktrees/`
+/// (so colocated git worktrees are cleaned alongside the main checkout).
+/// Use `--include-hidden <GLOB>` to override the list, `--no-hidden` to
+/// turn it off entirely, or `-a` to descend into every hidden dir.
+///
+/// Examples:
+///     putzen                                       # descends into `.worktrees` by default
+///     putzen --include-hidden '.{worktrees,jj}'   # one glob, two hidden dirs
+///     putzen --include-hidden '.work*'             # any hidden dir starting with `.work`
+///     putzen -a                                    # every hidden dir (== '*')
+///     putzen --no-hidden                           # skip all hidden dirs (legacy)
 struct PutzenCliArgs {
     /// show the version number
     #[argh(switch, short = 'v')]

--- a/src/bin/putzen.rs
+++ b/src/bin/putzen.rs
@@ -47,6 +47,43 @@ impl HiddenPolicy {
         }
         self.matcher.is_match(name)
     }
+
+    /// Build a policy from parsed CLI args. Enforces the mutual-exclusion
+    /// rules and applies the default `.worktrees` pattern when no
+    /// `--include-hidden` and no `-a` was passed.
+    fn from_args(args: &PutzenCliArgs) -> std::result::Result<Self, String> {
+        let dash_a = args.dive_into_hidden_folders;
+        let no_hidden = args.no_hidden;
+        let include_given = !args.include_hidden.is_empty();
+
+        if no_hidden && include_given {
+            return Err("`--no-hidden` and `--include-hidden` are mutually exclusive".into());
+        }
+        if no_hidden && dash_a {
+            return Err("`--no-hidden` and `-a` are mutually exclusive".into());
+        }
+        if dash_a && include_given {
+            return Err("`-a` and `--include-hidden` are mutually exclusive".into());
+        }
+
+        if no_hidden {
+            return Self::new(true, &[]);
+        }
+
+        // Resolve the active set of globs:
+        //   -a            -> ["*"]
+        //   --include-... -> user list
+        //   neither       -> [".worktrees"]
+        let owned: Vec<Glob> = if dash_a {
+            vec![parse_glob("*").expect("`*` is a valid glob")]
+        } else if include_given {
+            args.include_hidden.clone()
+        } else {
+            vec![parse_glob(".worktrees").expect("`.worktrees` is a valid glob")]
+        };
+
+        Self::new(false, &owned)
+    }
 }
 
 /// all supported this to clean up
@@ -80,9 +117,19 @@ struct PutzenCliArgs {
     #[argh(switch, short = 'L')]
     follow: bool,
 
-    /// dive into hidden folders too, e.g. `.git`
+    /// include every hidden directory (== --include-hidden '*')
     #[argh(switch, short = 'a')]
     dive_into_hidden_folders: bool,
+
+    /// skip every hidden directory (overrides the default `.worktrees`)
+    #[argh(switch)]
+    no_hidden: bool,
+
+    /// glob of hidden directories to descend into (repeatable). Match is
+    /// against the full basename including the leading dot, e.g.
+    /// `.worktrees`, `.{worktrees,jj}`, `.work*`. Default: `.worktrees`.
+    #[argh(option, from_str_fn(parse_glob))]
+    include_hidden: Vec<Glob>,
 
     /// path where to start with disk clean up.
     #[argh(positional, default = "PathBuf::from(\".\")")]
@@ -232,6 +279,8 @@ mod tests {
             yes_to_all: true,
             follow: false,
             dive_into_hidden_folders: false,
+            no_hidden: false,
+            include_hidden: Vec::new(),
             folder: root_folder.path().to_path_buf(),
         };
 
@@ -314,5 +363,111 @@ mod tests {
         let p = HiddenPolicy::new(true, &compiled).unwrap();
         assert!(!p.allows_hidden(".worktrees".as_ref()));
         assert!(!p.allows_hidden(".anything".as_ref()));
+    }
+
+    fn args_from(input: &[&str]) -> std::result::Result<PutzenCliArgs, argh::EarlyExit> {
+        PutzenCliArgs::from_args(&["putzen"], input)
+    }
+
+    #[test]
+    fn from_args_default_includes_worktrees_only() {
+        let args = args_from(&[]).unwrap();
+        let policy = HiddenPolicy::from_args(&args).unwrap();
+        assert!(policy.allows_hidden(".worktrees".as_ref()));
+        assert!(!policy.allows_hidden(".git".as_ref()));
+    }
+
+    #[test]
+    fn from_args_dash_a_includes_everything_hidden() {
+        let args = args_from(&["-a"]).unwrap();
+        let policy = HiddenPolicy::from_args(&args).unwrap();
+        assert!(policy.allows_hidden(".worktrees".as_ref()));
+        assert!(policy.allows_hidden(".git".as_ref()));
+        assert!(policy.allows_hidden(".whatever".as_ref()));
+    }
+
+    #[test]
+    fn from_args_no_hidden_rejects_everything() {
+        let args = args_from(&["--no-hidden"]).unwrap();
+        let policy = HiddenPolicy::from_args(&args).unwrap();
+        assert!(!policy.allows_hidden(".worktrees".as_ref()));
+        assert!(!policy.allows_hidden(".anything".as_ref()));
+    }
+
+    #[test]
+    fn from_args_include_hidden_overrides_default() {
+        let args = args_from(&["--include-hidden", ".git"]).unwrap();
+        let policy = HiddenPolicy::from_args(&args).unwrap();
+        assert!(policy.allows_hidden(".git".as_ref()));
+        // default `.worktrees` is replaced, not merged
+        assert!(!policy.allows_hidden(".worktrees".as_ref()));
+    }
+
+    #[test]
+    fn from_args_include_hidden_repeatable() {
+        let args = args_from(&[
+            "--include-hidden", ".git",
+            "--include-hidden", ".cache",
+        ]).unwrap();
+        let policy = HiddenPolicy::from_args(&args).unwrap();
+        assert!(policy.allows_hidden(".git".as_ref()));
+        assert!(policy.allows_hidden(".cache".as_ref()));
+        assert!(!policy.allows_hidden(".worktrees".as_ref()));
+    }
+
+    #[test]
+    fn from_args_brace_expansion_one_flag_two_dirs() {
+        let args = args_from(&["--include-hidden", ".{worktrees,jj}"]).unwrap();
+        let policy = HiddenPolicy::from_args(&args).unwrap();
+        assert!(policy.allows_hidden(".worktrees".as_ref()));
+        assert!(policy.allows_hidden(".jj".as_ref()));
+    }
+
+    #[test]
+    fn from_args_invalid_glob_errors_at_parse_time() {
+        // argh's from_str_fn surfaces the error at argument-parse time
+        let result = args_from(&["--include-hidden", "[bad"]);
+        let early_exit = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected parse error for invalid glob"),
+        };
+        let msg = format!("{early_exit:?}");
+        assert!(msg.contains("[bad"), "error should mention offending input: {msg}");
+    }
+
+    #[test]
+    fn from_args_no_hidden_conflicts_with_include_hidden() {
+        let args = args_from(&["--no-hidden", "--include-hidden", ".git"]).unwrap();
+        let result = HiddenPolicy::from_args(&args);
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected conflict error"),
+        };
+        assert!(err.contains("--no-hidden"), "got: {err}");
+        assert!(err.contains("--include-hidden"), "got: {err}");
+    }
+
+    #[test]
+    fn from_args_no_hidden_conflicts_with_dash_a() {
+        let args = args_from(&["--no-hidden", "-a"]).unwrap();
+        let result = HiddenPolicy::from_args(&args);
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected conflict error"),
+        };
+        assert!(err.contains("--no-hidden"), "got: {err}");
+        assert!(err.contains("-a"), "got: {err}");
+    }
+
+    #[test]
+    fn from_args_dash_a_conflicts_with_include_hidden() {
+        let args = args_from(&["-a", "--include-hidden", ".git"]).unwrap();
+        let result = HiddenPolicy::from_args(&args);
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected conflict error"),
+        };
+        assert!(err.contains("-a"), "got: {err}");
+        assert!(err.contains("--include-hidden"), "got: {err}");
     }
 }

--- a/src/bin/putzen.rs
+++ b/src/bin/putzen.rs
@@ -1,9 +1,10 @@
 use std::convert::TryFrom;
+use std::ffi::OsStr;
 use std::io::Result;
 use std::path::PathBuf;
 
 use argh::FromArgs;
-use globset::Glob;
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use jwalk::Parallelism;
 
 use putzen_cli::{
@@ -19,6 +20,33 @@ use putzen_cli::HighscoreObserver;
 /// offending input so CLI users see what they typed.
 fn parse_glob(s: &str) -> std::result::Result<Glob, String> {
     Glob::new(s).map_err(|e| format!("invalid glob `{s}`: {e}"))
+}
+
+/// Decides whether a hidden directory (basename starts with `.`) is allowed
+/// to be entered by the walker. Built once per run from CLI args.
+struct HiddenPolicy {
+    no_hidden: bool,
+    matcher: GlobSet,
+}
+
+impl HiddenPolicy {
+    fn new(no_hidden: bool, globs: &[Glob]) -> std::result::Result<Self, String> {
+        let mut b = GlobSetBuilder::new();
+        for g in globs {
+            b.add(g.clone());
+        }
+        let matcher = b.build().map_err(|e| format!("failed to build glob set: {e}"))?;
+        Ok(Self { no_hidden, matcher })
+    }
+
+    /// Should the walker enter this hidden basename?
+    /// Caller is responsible for only passing hidden names (starting with `.`).
+    fn allows_hidden(&self, name: &OsStr) -> bool {
+        if self.no_hidden {
+            return false;
+        }
+        self.matcher.is_match(name)
+    }
 }
 
 /// all supported this to clean up
@@ -241,5 +269,50 @@ mod tests {
         let err = parse_glob("[unterminated").expect_err("should fail");
         // error message includes the offending input so users can self-diagnose
         assert!(err.contains("[unterminated"), "got: {err}");
+    }
+
+    fn policy(globs: &[&str]) -> HiddenPolicy {
+        let compiled: Vec<Glob> = globs.iter().map(|g| parse_glob(g).unwrap()).collect();
+        HiddenPolicy::new(false, &compiled).unwrap()
+    }
+
+    #[test]
+    fn policy_default_worktrees_only() {
+        let p = policy(&[".worktrees"]);
+        assert!(p.allows_hidden(".worktrees".as_ref()));
+        assert!(!p.allows_hidden(".git".as_ref()));
+        assert!(!p.allows_hidden(".cache".as_ref()));
+    }
+
+    #[test]
+    fn policy_brace_expansion_two_dirs() {
+        let p = policy(&[".{worktrees,jj}"]);
+        assert!(p.allows_hidden(".worktrees".as_ref()));
+        assert!(p.allows_hidden(".jj".as_ref()));
+        assert!(!p.allows_hidden(".pijul".as_ref()));
+    }
+
+    #[test]
+    fn policy_star_matches_all_hidden() {
+        let p = policy(&["*"]);
+        assert!(p.allows_hidden(".worktrees".as_ref()));
+        assert!(p.allows_hidden(".git".as_ref()));
+        assert!(p.allows_hidden(".cache".as_ref()));
+    }
+
+    #[test]
+    fn policy_pattern_without_dot_matches_nothing_hidden() {
+        // documented footgun: pattern omits the leading dot, so it can
+        // never match a hidden basename (which always starts with `.`)
+        let p = policy(&["worktrees"]);
+        assert!(!p.allows_hidden(".worktrees".as_ref()));
+    }
+
+    #[test]
+    fn policy_no_hidden_rejects_everything() {
+        let compiled: Vec<Glob> = vec![parse_glob(".worktrees").unwrap()];
+        let p = HiddenPolicy::new(true, &compiled).unwrap();
+        assert!(!p.allows_hidden(".worktrees".as_ref()));
+        assert!(!p.allows_hidden(".anything".as_ref()));
     }
 }


### PR DESCRIPTION
## Summary

- `putzen` now descends into `.worktrees` by default so colocated git worktrees get cleaned in one run, without sweeping in every hidden directory.
- `--hidden <GLOB>` lets users opt extra hidden dirs into the walk (repeatable, matched against the full basename incl. leading dot). Spelled the same as ripgrep / fd.
- `--no-hidden` restores the strict pre-3.x behavior; `-a` keeps the "descend into all hidden" escape hatch. All three are mutually exclusive.

Closes #80