### PR TITLE
feat(snap): classic confinement so dot-folder caches are visible

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,17 @@ description: |
   It helps keeping your disk clean of build and dependency artifacts safely.
 
 grade: stable
-confinement: strict
+# Classic confinement is required because putzen reads and deletes
+# user cache directories (.cargo, .npm, .cache/huggingface, …) and
+# accepts arbitrary --root paths.  The default `home` interface
+# explicitly hides dot-files / dot-directories, which is exactly
+# the set putzen needs to see — so strict confinement leaves every
+# cache row stubbed out as empty.  Other disk-tool snaps (kondo,
+# dust, ncdu, tealdeer) sit on classic for the same reason.
+#
+# Publishing classic snaps requires a one-off store review request:
+#   https://forum.snapcraft.io/c/store-requests/19
+confinement: classic
 
 parts:
   putzen:
@@ -20,5 +30,3 @@ parts:
 apps:
   putzen:
     command: bin/putzen
-    plugs:
-      - home


### PR DESCRIPTION
- The `home` interface deliberately hides dot-folders, which is exactly where every cache lives — strict confinement leaves the TUI showing every row as empty.
- Switches to classic so putzen reads the filesystem like any other process; matches what `kondo`, `dust`, `ncdu`, `tealdeer` do for the same reason.
- Publishing classic snaps needs a one-off store review request (linked from the manifest comment). Local installs work today with `sudo snap install --classic --dangerous ./putzen_*.snap`.
- Depends on #87 landing first so this PR's CI run actually exercises the new snap-lint check.