### PR TITLE
fix(ci): run snapcraft lint under the lxd group

### DIFF
--- a/.github/workflows/snap-check.yml
+++ b/.github/workflows/snap-check.yml
@@ -44,8 +44,12 @@ jobs:
         id: build
         uses: snapcore/action-build@v1
 
+      # `snapcraft lint` spins up a craft-providers LXD instance — that
+      # needs the `lxd` group on the current shell.  snapcore/action-build
+      # adds the runner to the group, but membership only takes effect for
+      # a fresh login; `sg` opens one for this single command.
       - name: lint built snap
-        run: snapcraft lint ${{ steps.build.outputs.snap }}
+        run: sg lxd -c "snapcraft lint ${{ steps.build.outputs.snap }}"
 
       # Hand the artefact to anyone reviewing the PR for local install with
       # `sudo snap install --classic --dangerous ./<file>.snap`.


### PR DESCRIPTION
- The lint step from #87 fails at runtime because `snapcraft lint` opens an LXD instance, and the shell GitHub Actions hands to `run:` doesn't have the lxd group active yet (group membership only kicks in for a fresh login).
- `sg lxd -c '...'` wraps that single step in a new login session with the group, no other workflow rewiring needed.