### PR TITLE
fix(ci): release-plz under the canonical org + cargo token

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,33 +1,28 @@
-## See https://release-plz.ieni.dev/docs/github/quickstart
-
 name: Release PR
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   pull-requests: write
   contents: write
 
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
-
 jobs:
   release-plz:
-    name: Release-plz
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Run release-plz pr
-        uses: MarcoIeni/release-plz-action@v0.5
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
         with:
           command: release-pr
           config: release-plz.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
- `MarcoIeni/release-plz-action` moved under `release-plz/action`; switch to the canonical reference so we stay on the supported action.
- Pass `CARGO_REGISTRY_TOKEN` so release-plz can dry-run publish during the release-PR phase and catch crates.io regressions before the tag.
- Trim the yaml while we're touching it (compact branch list, drop redundant step names, drop the explicit `GITHUB_TOKEN` on checkout — already the default).