### PR TITLE
build(deps): bump bstr from 1.12.1 to 1.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,12 +95,12 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "a4e308e67087593070530a666f7fe8815cbd2e61d8f5b7313b71b7d721d1dfde"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]


### PR DESCRIPTION
- Routine patch bump.  Transitive switch from `serde` to `serde_core` upstream — no API change at the call site.